### PR TITLE
VST-15: border-bottom instead of text-decoration

### DIFF
--- a/src/components/info-panel.js
+++ b/src/components/info-panel.js
@@ -9,6 +9,9 @@ const Title = styled.h1`
     color: #63686a;
     margin: 20px;
     border-bottom: 0.5rem solid palegreen;
+    width: -moz-fit-content;
+    width: fit-content;
+    display: table; 
 `;
 
 const Panel = styled.div`


### PR DESCRIPTION
Fixed using border-bottom instead of text-decoration and then fit the header element to the width of the text using:

```
width: -moz-fit-content
width: fit-content
display: table // for IE 11
```

